### PR TITLE
branchJCM|Cuentas-JC-21|Campo creado y oculto en la vista create|

### DIFF
--- a/custom/Extension/modules/Accounts/Ext/Language/es_LA.lang.php
+++ b/custom/Extension/modules/Accounts/Ext/Language/es_LA.lang.php
@@ -277,3 +277,4 @@ $mod_strings['LBL_CURRENCY_10'] = 'LBL_CURRENCY';
 $mod_strings['LBL_POTENCIAL_CUENTA'] = 'Potencial de la Cuenta';
 $mod_strings['LBL_SUBTIPO_CUENTA'] = 'Subtipo de Cuenta';
 $mod_strings['LBL_RECORDVIEW_PANEL16'] = 'Origen';
+$mod_strings['LBL_TCT_PROSPECTO_CONTACTADO_CHK'] = 'Prospecto Contactado';

--- a/custom/Extension/modules/Accounts/Ext/Vardefs/sugarfield_tct_prospecto_contactado_chk_c.php
+++ b/custom/Extension/modules/Accounts/Ext/Vardefs/sugarfield_tct_prospecto_contactado_chk_c.php
@@ -1,0 +1,7 @@
+<?php
+ // created: 2018-07-12 13:48:11
+$dictionary['Account']['fields']['tct_prospecto_contactado_chk_c']['labelValue']='Prospecto Contactado';
+$dictionary['Account']['fields']['tct_prospecto_contactado_chk_c']['enforced']='';
+$dictionary['Account']['fields']['tct_prospecto_contactado_chk_c']['dependency']='';
+
+ ?>

--- a/custom/modules/Accounts/clients/base/views/create/create.js
+++ b/custom/modules/Accounts/clients/base/views/create/create.js
@@ -62,6 +62,9 @@
         this.$("[data-panelname='LBL_RECORDVIEW_PANEL6']").hide();
         this.$("[data-panelname='LBL_RECORDVIEW_PANEL9']").hide();
 
+        //Ocultar Div "Prospecto Contactado"
+        $('div[data-name=tct_prospecto_contactado_chk_c]').hide();
+
         /* @author F. Javier Garcia S. 10/07/2018
             Agregar dependencia al panel NPS, para ser visible si "Tipo de Cuenta" es "Cliente".
          */
@@ -381,6 +384,10 @@
         this.model.fields['tipo_registro_c'].options = new_options;
 
         this.model.on('change:name', this.cleanName, this);
+/*
+        //Ocultar Div "Prospecto Contactado"
+        this.$('div[data-name=tct_prospecto_contactado_chk_c]').hide();
+  */
     },
 
     /** BEGIN CUSTOMIZATION:

--- a/custom/modules/Accounts/clients/base/views/record/record.php
+++ b/custom/modules/Accounts/clients/base/views/record/record.php
@@ -561,6 +561,8 @@ array (
               ),
               89 => 
               array (
+                  'name' => 'tct_prospecto_contactado_chk_c',
+                  'label' => 'LBL_TCT_PROSPECTO_CONTACTADO_CHK',
               ),
             ),
           ),


### PR DESCRIPTION
Requerimiento Cuentas-JC-21 concluido:
"Crear un nuevo campo con la siguiente definición:
Tipo de campo: Casilla de verificación
Nombre de campo: tct_prospecto_contactado_chk
Etiqueta visible: Prospecto Contactado
Campo oculto en la vista create.js"