### PR TITLE
Habilitacion de borrado del boton Guardar al marcar Oportunidad Perdida

### DIFF
--- a/custom/modules/Opportunities/clients/base/views/record/record.js
+++ b/custom/modules/Opportunities/clients/base/views/record/record.js
@@ -28,6 +28,8 @@
 		});
 		this.model.fields['forecast_c'].options = opciones_forecast;
 		*/
+          this.on('render', this._HideSaveButton, this);  //Función ocultar botón guardar cuando Oportunidad perdida tiene un valor TRUE 18/07/18
+          this.model.on("change:tct_oportunidad_perdida_chk_c",this._HideSaveButton, this);
 
 		this.model.addValidationTask('check_monto_c', _.bind(this._ValidateAmount, this));
     this.model.addValidationTask('ratificacion_incremento_c', _.bind(this.validaTipoRatificacion, this));
@@ -875,4 +877,14 @@ console.log(name);
 			this.model.set("porciento_ri_c", percent);
 		}
 	},
+
+    _HideSaveButton: function () {
+         if (this.model.get('tct_oportunidad_perdida_chk_c'))
+         {
+            $('[name="save_button"]').eq(0).hide();
+         }
+         else {$('[name="save_button"]').eq(0).show();}
+    }
+
 })
+


### PR DESCRIPTION
Se habilitó en Record.js el funcionamiento de ocultar dicho botón.