### PR TITLE
Validacion para la minuta relacionada en la vista de la reunion.

### DIFF
--- a/custom/modules/Meetings/clients/base/views/record/record.php
+++ b/custom/modules/Meetings/clients/base/views/record/record.php
@@ -384,6 +384,7 @@ array (
               array (
                 'name' => 'minut_minutas_meetings_name',
                 'label' => 'LBL_MINUT_MINUTAS_MEETINGS_FROM_MINUT_MINUTAS_TITLE',
+                'readonly' => true,
               ),
               1 => 
               array (


### PR DESCRIPTION
Al tener una minuta y estar en la vista de detalle de la reunion, en el campo de minutas se valida que la minuta mostrada, solo pueda ser RedOnly.