### PR TITLE
Notificaciones-Reasignación

### DIFF
--- a/custom/clients/base/api/reAsignarCuentas.php
+++ b/custom/clients/base/api/reAsignarCuentas.php
@@ -75,7 +75,7 @@ SQL;
                 $User = new User();
                 $User->retrieve($reAsignado);
                 $para = $User->email1;
-                if(($account->tipo_registro_c == 'Cliente' || $account->tipo_registro_c == 'Prospecto') && $para != null)
+                if($para != null)
                 {
           			if($User->optout_c == 1)
           			{


### PR DESCRIPTION
Se quita validación del tipo de persona para la creación de las Notificaciones en la reasignación de promotores