### PR TITLE
Ajuste mensaje de error 3 checks lead no viable

### DIFF
--- a/custom/modules/Accounts/clients/base/views/record/record.js
+++ b/custom/modules/Accounts/clients/base/views/record/record.js
@@ -1651,7 +1651,7 @@
             (this.model.get('user_id_c')== "cc736f7a-4f5f-11e9-856a-a0481cdf89eb" && this.model.get('user_id1_c')== "cc736f7a-4f5f-11e9-856a-a0481cdf89eb" && this.model.get('user_id2_c')== "cc736f7a-4f5f-11e9-856a-a0481cdf89eb")){
             app.alert.show("Cumple 3 checks", {
             level: "error",
-                title: 'Esta cuenta no se puede convertir a prospecto ya que es un lead no viable.',
+                title: 'Esta cuenta no se puede convertir a prospecto ya que es un lead no viable en los tres productos.',
                 autoClose: false
             });
             return;


### PR DESCRIPTION
- Se modifica el mensaje de error al intentar convertir una cuenta tipo lead a Prospecto Contactado si la cuenta cuenta con los 3 checks de lead no viable en los tres productos.