### PR TITLE
Ajuste en Reuniones al guardar reunion sin objetivos

### DIFF
--- a/custom/modules/Meetings/meetings_hooks.php
+++ b/custom/modules/Meetings/meetings_hooks.php
@@ -332,13 +332,20 @@ class Meetings_Hooks
       $reunionInvitado->save();
       //Agrega objetivos
       if($bean->load_relationship('meetings_minut_objetivos_1')) {
+          $GLOBALS['log']->fatal('Trae relacion de objetivos');
         $relatedBeans = $bean->meetings_minut_objetivos_1->getBeans();
         foreach($relatedBeans as $rel){
           $beanObjetivo = BeanFactory::newBean('minut_Objetivos');
+            $GLOBALS['log']->fatal('Imprime objetivos');
           $beanObjetivo->name = $rel->name;
           $beanObjetivo->description = $rel->description;
           $beanObjetivo->meetings_minut_objetivos_1meetings_ida = $reunionInvitado->id;
+            $GLOBALS['log']->fatal($reunionInvitado->id);
+            $GLOBALS['log']->fatal($beanObjetivo->meetings_minut_objetivos_1meetings_ida);
           $beanObjetivo->save();
+            $reunionInvitado->load_relationship('meetings_minut_objetivos_1');
+            $reunionInvitado->meetings_minut_objetivos_1->add($beanObjetivo->id);
+            $GLOBALS['log']->fatal('Se creo relacion');
         }
       }
     }

--- a/custom/modules/Meetings/meetings_hooks.php
+++ b/custom/modules/Meetings/meetings_hooks.php
@@ -332,20 +332,15 @@ class Meetings_Hooks
       $reunionInvitado->save();
       //Agrega objetivos
       if($bean->load_relationship('meetings_minut_objetivos_1')) {
-          $GLOBALS['log']->fatal('Trae relacion de objetivos');
         $relatedBeans = $bean->meetings_minut_objetivos_1->getBeans();
         foreach($relatedBeans as $rel){
           $beanObjetivo = BeanFactory::newBean('minut_Objetivos');
-            $GLOBALS['log']->fatal('Imprime objetivos');
           $beanObjetivo->name = $rel->name;
           $beanObjetivo->description = $rel->description;
           $beanObjetivo->meetings_minut_objetivos_1meetings_ida = $reunionInvitado->id;
-            $GLOBALS['log']->fatal($reunionInvitado->id);
-            $GLOBALS['log']->fatal($beanObjetivo->meetings_minut_objetivos_1meetings_ida);
           $beanObjetivo->save();
             $reunionInvitado->load_relationship('meetings_minut_objetivos_1');
             $reunionInvitado->meetings_minut_objetivos_1->add($beanObjetivo->id);
-            $GLOBALS['log']->fatal('Se creo relacion');
         }
       }
     }


### PR DESCRIPTION
Con esto, al crear una reunion sin cuenta relacionada y tener invitados y posteriormente editar dicha reunion añadiendo una cuenta, se crearán las copias a los invitamos mostrando los objetivos de la reunion.