### PR TITLE
Vista 360 - Proveedor: Se habilita vista 360 para cuentas tipo Proveedor

### DIFF
--- a/custom/Extension/modules/Accounts/Ext/Vardefs/sugarfield_show_panel_c.php
+++ b/custom/Extension/modules/Accounts/Ext/Vardefs/sugarfield_show_panel_c.php
@@ -1,17 +1,19 @@
 <?php
- // created: 2019-04-15 17:19:11
-$dictionary['Account']['fields']['show_panel_c']['duplicate_merge_dom_value'] = 0;
-$dictionary['Account']['fields']['show_panel_c']['labelValue'] = 'Muestra panel';
-$dictionary['Account']['fields']['show_panel_c']['calculated'] = 'true';
-$dictionary['Account']['fields']['show_panel_c']['formula'] = 'ifElse(
+ // created: 2019-07-16 18:38:51
+$dictionary['Account']['fields']['show_panel_c']['duplicate_merge_dom_value']=0;
+$dictionary['Account']['fields']['show_panel_c']['labelValue']='Muestra panel';
+$dictionary['Account']['fields']['show_panel_c']['calculated']='1';
+$dictionary['Account']['fields']['show_panel_c']['formula']='ifElse(
 or(
 equal($tipo_registro_c,"Lead"),
 equal($tipo_registro_c,"Prospecto"),
-equal($tipo_registro_c,"Cliente")
+equal($tipo_registro_c,"Cliente"),
+equal($tipo_registro_c,"Proveedor")
 ),
 true,
 false
 )';
-$dictionary['Account']['fields']['show_panel_c']['enforced'] = 'true';
-$dictionary['Account']['fields']['show_panel_c']['dependency'] = '';
+$dictionary['Account']['fields']['show_panel_c']['enforced']='1';
+$dictionary['Account']['fields']['show_panel_c']['dependency']='';
 
+ ?>


### PR DESCRIPTION
Ejecutar scripts en BD unfiin

set sql_safe_updates=0;

update accounts_cstm
set show_panel_c =1
where tipo_registro_c='Proveedor'
;


insert ignore into tct02_resumen_cstm(id_c) 
select accounts_cstm.id_c
from accounts_cstm 
left join tct02_resumen on tct02_resumen.id = accounts_cstm.id_c
where tipo_registro_c='Proveedor'
and tct02_resumen.id is null
;

insert ignore into tct02_resumen(id, name, date_entered, date_modified) 
select 
	accounts_cstm.id_c,
	accounts.name,
    utc_timestamp(),
    utc_timestamp()
from accounts_cstm 
inner join accounts on accounts.id = accounts_cstm.id_c
left join tct02_resumen on tct02_resumen.id = accounts_cstm.id_c
where tipo_registro_c='Proveedor'
and tct02_resumen.id is null
;