### PR TITLE
Ajuste Reuniones - Conferencia checkbox - 143665

### DIFF
--- a/custom/Extension/modules/Meetings/Ext/Dependencies/readOnly.php
+++ b/custom/Extension/modules/Meetings/Ext/Dependencies/readOnly.php
@@ -233,3 +233,19 @@ $dependencies['Meetings']['reunion_objetivos'] = array(
         ),
     ),
 );
+
+$dependencies['Meetings']['tct_conferencia_chk_c'] = array(
+    'hooks' => array("all"),
+    'trigger' => 'true',
+    'triggerFields' => array('status','id','tct_conferencia_chk_c'),
+    'onload' => true,
+    'actions' => array(
+        array(
+            'name' => 'ReadOnly',
+            'params' => array(
+                'target' => 'tct_conferencia_chk_c',
+                'value' => 'not(equal($status,"Planned")',
+            ),
+        ),
+    ),
+);


### PR DESCRIPTION
Se habilita una dependencia para el campo, sólo podrá ser editable siempre y cuando el estatus de la reunión sea Planificada.