### PR TITLE
#148691_CP_Correcciones_03012020

### DIFF
--- a/custom/Extension/modules/Tasks/Ext/Dependencies/SetValue.php
+++ b/custom/Extension/modules/Tasks/Ext/Dependencies/SetValue.php
@@ -12,7 +12,7 @@ $dependencies['Tasks']['ayuda_asesor_cp_c']= array
 		'params'=> array(
 			'target'=>'name',
 			'label'=>'LBL_SUBJECT',
-			'value'=>'ifElse(equal($ayuda_asesor_cp_c,"1"),concat("AYUDA CP - ",related($leads,"name")), "")',
+			'value'=>'ifElse(equal($ayuda_asesor_cp_c,"1"),concat("AYUDA CP - ",related($leads,"name"),related($accounts,"name")), "")',
 		),
 	),
 	

--- a/custom/Extension/modules/Tasks/Ext/Language/es_LA.lang.php
+++ b/custom/Extension/modules/Tasks/Ext/Language/es_LA.lang.php
@@ -1,3 +1,3 @@
 <?php
 // WARNING: The contents of this file are auto-generated.
-$mod_strings['LBL_AYUDA_ASESOR_CP'] = 'Solicita Ayuda de Asesor';
+$mod_strings['LBL_AYUDA_ASESOR_CP'] = 'Ayuda Centro de Prospección';

--- a/custom/Extension/modules/Tasks/Ext/Vardefs/sugarfield_ayuda_asesor_cp_c.php
+++ b/custom/Extension/modules/Tasks/Ext/Vardefs/sugarfield_ayuda_asesor_cp_c.php
@@ -1,6 +1,6 @@
 <?php
- // created: 2019-12-26 18:44:38
-$dictionary['Task']['fields']['ayuda_asesor_cp_c']['labelValue']='Solicita Ayuda de Asesor';
+ // created: 2020-01-02 13:02:44
+$dictionary['Task']['fields']['ayuda_asesor_cp_c']['labelValue']='Ayuda Centro de Prospección';
 $dictionary['Task']['fields']['ayuda_asesor_cp_c']['enforced']='';
 $dictionary['Task']['fields']['ayuda_asesor_cp_c']['dependency']='';
 

--- a/custom/modules/Calls/clients/base/views/record/record.js
+++ b/custom/modules/Calls/clients/base/views/record/record.js
@@ -504,7 +504,35 @@
                 success: _.bind(function (model) {
 					// 
                     //if(model.get('tct_no_contactar_chk_c')==true){
+					//regimen_fiscal_c	
+					//Persona Fisica,Persona Fisica con Actividad Empresarial,Persona Moral
 					if( model.get('subtipo_registro_c') == "1" ){
+						
+						if (model.get('nombre_empresa_c')=='' && model.get('regimen_fiscal_c')=='Persona Moral') {
+							errors['nombre_empresa_c'] = errors['nombre_empresa_c'] || {};
+							errors['nombre_empresa_c'].required = true;
+							texto += "<b>Nombre de la Empresa</b> <br>";
+							requerido++;
+						}
+						
+						if (model.get('nombre_c')=='' && model.get('apellido_paterno_c')=='' &&
+							   model.get('regimen_fiscal_c')!='Persona Moral') {
+							errors['nombre_c'] = errors['nombre_c'] || {};
+							errors['nombre_c'].required = true;
+							texto += "<b>Nombre</b> <br>";
+							errors['apellido_paterno_c'] = errors['apellido_paterno_c'] || {};
+							errors['apellido_paterno_c'].required = true;
+							texto += "<b>Apellido Paterno</b> <br>";
+							requerido++;
+						}
+						
+						if (model.get('origen_c')=='' ) {
+							errors['origen_c'] = errors['origen_c'] || {};
+							errors['origen_c'].required = true;
+							texto += "<b>Origen</b> <br>";
+							requerido++;
+						}
+						
 						if (model.get('macrosector_c')=='') {
 							errors['macrosector_c'] = errors['macrosector_c'] || {};
 							errors['macrosector_c'].required = true;
@@ -542,7 +570,7 @@
 							errors['phone_work'] = errors['phone_work'] || {};
 							errors['phone_work'].required = true;
 							
-							texto += "<b>Teléfono</b> <br>";
+							texto += "<b>Necesita agregar al menos un teléfono</b> <br>";
 							requerido++;
 						}
 						
@@ -553,7 +581,7 @@
 							requerido++;
 						}
 						
-						if (model.get('puesto_c')=='') {
+						if (model.get('puesto_c')=='' && model.get('regimen_fiscal_c')!='Persona Moral') {
 							errors['puesto_c'] = errors['puesto_c'] || {};
 							errors['puesto_c'].required = true;
 							texto += "<b>Puesto</b> <br>";


### PR DESCRIPTION
Correcciones de incidencias del 03-01-2020

Llamada Realizada	"Se tienen los siguientes incidentes en la validación de campos requeridos en Leads:
Cuando el Lead es Moral:
- No debe pedir  Piuesto
- Debe pedir Nombre de Empresa
- Debe pedir Origen

Cuando el Lead es Física:
- Debe pedir Nombre y Apellidos
- Debe pedir Origen"
Acción de Ayuda en Tareas	Cambiar etiqueta de campo; de Solicita Ayuda de Asesor a "Ayuda Centro de Prospección"
Acción de Ayuda en Tareas	El campo Nombre deberá obtener el nombre del registro asociado(Lead o Cuenta)
Acción de Ayuda en Tareas	"No debe permitir seleccionar el campo Ayuda Centro de Prospección a usuarios con puesto Agente Telefónico.
Usuario igomez es agente y le permite seleccionar."