### PR TITLE
#148691_CP_Readonly_duedate_task_06022020

### DIFF
--- a/custom/Extension/application/Ext/Language/es_LA.sugar_task_status_cp_list.php
+++ b/custom/Extension/application/Ext/Language/es_LA.sugar_task_status_cp_list.php
@@ -1,0 +1,8 @@
+<?php
+ // created: 2020-02-06 23:40:21
+
+$app_list_strings['task_status_cp_list']=array (
+  'Exitoso' => 'Exitoso',
+  'No Exitoso' => 'No Exitoso',
+  'In Progress' => 'En Procesos',
+);

--- a/custom/Extension/modules/Tasks/Ext/Dependencies/ReadOnly.php
+++ b/custom/Extension/modules/Tasks/Ext/Dependencies/ReadOnly.php
@@ -25,16 +25,6 @@ $dependencies['Tasks']['readonly_fields'] = array
 				'value'=>'equal($ayuda_asesor_cp_c,"1")',
 			),
 		),
-		
-		array(
-			'name' => 'ReadOnly',
-			'params' => array
-			(
-				'target' => 'date_due',
-				'value'=>'equal($ayuda_asesor_cp_c,"1")',
-			),
-		),
-		
 	),
 );
 

--- a/custom/Extension/modules/Tasks/Ext/Dependencies/ReadOnly.php
+++ b/custom/Extension/modules/Tasks/Ext/Dependencies/ReadOnly.php
@@ -28,6 +28,24 @@ $dependencies['Tasks']['readonly_fields'] = array
 	),
 );
 
+$dependencies['Tasks']['setoptions_status_ayuda_c'] = array(
+   'hooks' => array("all"),
+   'trigger' => 'true',
+   'triggerFields' => array('ayuda_asesor_cp_c','status'),
+   'onload' => true,
+   'actions' => array(
+     array(
+       'name' => 'SetOptions',
+       'params' => array(
+         'target' => 'status',
+         'keys' => 'ifElse(equal($ayuda_asesor_cp_c,"1"),getDropdownKeySet("task_status_cp_list"),getDropdownKeySet("task_status_dom"))',
+         'labels' => 'ifElse(equal($ayuda_asesor_cp_c,"1"),getDropdownKeySet("task_status_cp_list"),getDropdownValueSet("task_status_dom"))',
+       ),
+     ),
+   ),
+);
+
+
 
 //Dependencia para ocultar en Tareas la cuenta y así asignar una única a la relación Adrian Arauz 20/707/18
 /*$dependencies['Tasks']['TareasNo'] = array(


### PR DESCRIPTION
Cambio en tareas se quita el solo de lectura para fecha fin