### PR TITLE
#11334 Crédito 3.1 - Ventas Anuales dependency

### DIFF
--- a/custom/Extension/modules/Accounts/Ext/Dependencies/readOnly.php
+++ b/custom/Extension/modules/Accounts/Ext/Dependencies/readOnly.php
@@ -223,6 +223,44 @@ $dependencies['Accounts']['empleados_c'] = array
     'notActions' => array(),
 );
 
+// solo lectura si el campo Ventas Anuales Uni2 esta en true
 
+$dependencies['Accounts']['tct_ano_ventas_ddw_c'] = array
+(
+    'hooks' => array("edit"),
+    'trigger' => 'true',
+    'triggerFields' => array('ventas_anuales_uni2_c'),
+    'onload' => true,
+    'actions' => array(
+        array(
+            'name' => 'ReadOnly',
+            'params' => array(
+                'target' => 'tct_ano_ventas_ddw_c',
+                'label' => 'LBL_EMPLEADOS',
+                'value' => 'equal($ventas_anuales_uni2_c, true)',
+            ),
+        ),
+    ),
+    'notActions' => array(),
+);
 
+// solo lectura si el campo Ventas Anuales Uni2 esta en true
+$dependencies['Accounts']['ventas_anuales_c'] = array
+(
+    'hooks' => array("edit"),
+    'trigger' => 'true',
+    'triggerFields' => array('ventas_anuales_uni2_c'),
+    'onload' => true,
+    'actions' => array(
+        array(
+            'name' => 'ReadOnly',
+            'params' => array(
+                'target' => 'ventas_anuales_c',
+                'label' => 'LBL_EMPLEADOS',
+                'value' => 'equal($ventas_anuales_uni2_c, true)',
+            ),
+        ),
+    ),
+    'notActions' => array(),
+);
 

--- a/custom/Extension/modules/Accounts/Ext/Language/es_LA.lang.php
+++ b/custom/Extension/modules/Accounts/Ext/Language/es_LA.lang.php
@@ -333,3 +333,4 @@ $mod_strings['LBL_ESTADO_RFC'] = 'Estado de validación RFC';
 $mod_strings['LBL_RFC_QR'] = 'RFC QR';
 $mod_strings['LBL_PATH_IMG_QR'] = 'Ruta de imagen QR';
 $mod_strings['LBL_TOTAL_EMPLEADOS_C'] = 'Número Exacto Empleados';
+$mod_strings['LBL_VENTAS_ANUALES_UNI2_C'] = 'Ventas Anuales Uni2';

--- a/custom/Extension/modules/Accounts/Ext/Vardefs/sugarfield_ventas_anuales_uni2_c.php
+++ b/custom/Extension/modules/Accounts/Ext/Vardefs/sugarfield_ventas_anuales_uni2_c.php
@@ -1,0 +1,7 @@
+<?php
+ // created: 2020-07-13 15:48:58
+$dictionary['Account']['fields']['ventas_anuales_uni2_c']['labelValue']='Ventas Anuales Uni2';
+$dictionary['Account']['fields']['ventas_anuales_uni2_c']['enforced']='';
+$dictionary['Account']['fields']['ventas_anuales_uni2_c']['dependency']='';
+
+ ?>


### PR DESCRIPTION
Se creo campo nuevo ventas_anuales_uni2_c y pone en solo lectura las ventas anuales y año de ventas en la sección de potencial del modulo de Cuentas